### PR TITLE
Fix for issue #2

### DIFF
--- a/ansiescapes.py
+++ b/ansiescapes.py
@@ -5,7 +5,11 @@ import os
 ESC = '\u001B['
 isTerminalApp = os.environ.get('TERM_PROGRAM') == 'Apple_Terminal'
 
-def _(s): return s.decode('unicode_escape');
+def _(s): 
+  if hasattr(s, "decode"):
+    return s.decode('unicode_escape')
+  else:
+    return s
 
 def cursorTo(x, y = None):
   if (not isinstance(x, numbers.Number)):


### PR DESCRIPTION
Error:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "path\to\ansiescapes.py", line 53, in <module>
    cursorLeft = _(ESC + 'G');
  File "path\to\ansiescapes.py", line 8, in _
    def _(s): return s.decode('unicode_escape');
AttributeError: 'str' object has no attribute 'decode'

Fix:

Replaced:
 "def _(s): return s.decode('unicode_decode');"
With:
"def _(s):
    if hasattr(s, "decode"):
        return s.decode("unicode_escape")
    else:
        return s